### PR TITLE
Modify subsampling logic and docstring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 large_data/*
+__pycache__/

--- a/build/lib/dspin/plot.py
+++ b/build/lib/dspin/plot.py
@@ -4,6 +4,7 @@
 @Author  :   Jialong Jiang, Yingying Gong
 '''
 
+import warnings
 import matplotlib.pyplot as plt
 import matplotlib.patheffects as patheffects
 from sklearn.cluster import KMeans
@@ -141,7 +142,7 @@ def assign_program_position(onmf_rep_ori, umap_all, repulsion=2):
 
     return program_umap_pos
 
-def gene_program_on_umap(onmf_rep, umap_all, program_umap_pos, fig_folder=None, subsample=True):
+def gene_program_on_umap(onmf_rep, umap_all, program_umap_pos, fig_folder=None, subsample=True, target_subsample_size=20000):
     """
     Plot gene programs on the UMAP plot.
 
@@ -151,16 +152,25 @@ def gene_program_on_umap(onmf_rep, umap_all, program_umap_pos, fig_folder=None, 
     program_umap_pos (numpy.ndarray): The assigned positions of gene programs on the UMAP plot.
     fig_folder (str): The folder where the output figure is saved.
     subsample (bool): Whether to subsample the data for plotting.
+    target_subsample_size (int): The number of cells to subsample to for large datasets. Defaults to 20,000. If the
+    number of cells is smaller than this size, will default to the number of cells.
 
     Returns:
-    str: Path of the created figure.
+    str or None: Path of the created figure if created, None otherwise
     """
 
     num_spin = onmf_rep.shape[1]
 
     if subsample:
-        num_subsample = 20000
-        sub_ind = np.random.choice(onmf_rep.shape[0], num_subsample, replace=False)
+        num_cells = onmf_rep.shape[0]
+        if num_cells < target_subsample_size:
+            warnings.warn(
+                f"Requested subsampling to {target_subsample_size} cells but dataset only has "
+                f"{num_cells} cells. Using all available cells.",
+                UserWarning
+            )
+        subsample_size = min(target_subsample_size, num_cells)
+        sub_ind = np.random.choice(onmf_rep.shape[0], subsample_size, replace=False)
         onmf_rep = onmf_rep[sub_ind, :]
         umap_all = umap_all[sub_ind, :]
 


### PR DESCRIPTION
When running `gene_program_on_umap`, the subsample parameter in the function expects 20,000 cells. When there are fewer than 20,000 the program throws an unexpected error.

This PR changes `gene_program_on_umap`. It adds a parameter for subsample target size, which defaults to 20,000. The function now uses the minimum of this subsample target size and the number of cells when subsampling. It warns the user that all of the cells are being used.